### PR TITLE
DM-24062: Remove reference band calib_psf_used

### DIFF
--- a/yml/hsc.yaml
+++ b/yml/hsc.yaml
@@ -172,11 +172,6 @@ tables:
     datatype: boolean
     description:
     mysql:datatype: BOOLEAN
-  - name: calib_psf_used
-    "@id": "#Object.calib_psf_used"
-    datatype: boolean
-    description:
-    mysql:datatype: BOOLEAN
   - name: gRa
     "@id": "#Object.gRa"
     datatype: double


### PR DESCRIPTION
because it is redundant with the per-band
[grizy]Calib_psf_used